### PR TITLE
Switching MongoDB for a standalone NeDB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ tmp*
 node_modules/
 npm-debug.log
 lib/
+db-data/

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "commander": "^2.8.1",
     "feathers": "^1.1.0-pre.0",
     "feathers-hooks": "^0.5.0",
-    "feathers-mongodb": "^0.3.3",
+    "feathers-nedb": "^0.1.0",
     "madison": "0.0.7"
   }
 }

--- a/src/config.js
+++ b/src/config.js
@@ -1,5 +1,4 @@
 const config = {
-  mongodb: process.env.MONGODB || 'mongodb://localhost:27017/place-my-order',
   delay: 0,
   port: process.env.PORT || 3030
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import feathers from 'feathers';
 import bodyParser from 'body-parser';
 import hooks from 'feathers-hooks';
-import mongodb from 'feathers-mongodb';
+import NeDB from 'feathers-nedb';
 import madison from 'madison';
 
 import config from './config';
@@ -50,14 +50,8 @@ const api = feathers()
 
       return Object.keys(result).map(key => result[key]);
     }))
-    .use('/restaurants', mongodb({
-      collection: 'restaurants',
-      connectionString: config.mongodb
-    }))
-    .use('/orders', mongodb({
-      collection: 'orders',
-      connectionString: config.mongodb
-    }));
+    .use('/restaurants', new NeDB('restaurants'))
+    .use('/orders', new NeDB('orders'));
 
   api.service('orders')
     .before(serviceHooks.addDelay(config.delay))


### PR DESCRIPTION
This is everything it took to migrate the Feathers API from MongoDB to a standalone NeDB file-system based database.
