### PR TITLE
Configure socket io to work with CORS

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,9 +34,13 @@ function fromRestaurants(mapper) {
   };
 }
 
+// Allow CORS websocket connections:
+const io = feathers.socketio();
+io.origins('*:*');
+
 const api = feathers()
     .configure(feathers.rest())
-    .configure(feathers.socketio())
+    .configure(io)
     .configure(hooks())
     .use(bodyParser.json())
     .use(bodyParser.urlencoded({ extended: true }))


### PR DESCRIPTION
### Case
- PMO app needs to talk via websockets with API that is available on a different domain name, e.g.:
`https://pmo.com` to talk to `https://www.place-my-order.com/api`

### Problem
- The websocket connection is not getting established. No errors can be seen anywhere.
- Is reproducable in local, e.g. change PMO app's api url to `api.local` and update `/etc/hosts` accordingly.

### Solution
- When PMO has to talk to API deployed on a different domain name we need to configure socket io server to allow CORS.

### TODO
- [ ] Provide links to websocket documentation about this issue and configuration.

### Demo

Here is the working result (w/o the fix there will be no WS connection in Network for the API):

![image](https://user-images.githubusercontent.com/1895948/58589224-6751d200-822f-11e9-9ab2-25fc1a783227.png)

![image](https://user-images.githubusercontent.com/1895948/58589262-7b95cf00-822f-11e9-8cb7-45e3dc60204e.png)
