### PR TITLE
endponts created for /favorites

### DIFF
--- a/src/hooks.js
+++ b/src/hooks.js
@@ -74,7 +74,7 @@ exports.checkQueryParam = function checkQueryParm(field) {
 // Requiring certain fields to exist
 exports.checkRequiredFields = function checkRequiredFields(fields) {
   return function(hook, next) {
-    let missingFields= [];
+    let missingFields = [];
     let reqData = hook.data;
     fields.forEach(field => {
       if(!(field in reqData)) {

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,25 @@ function fromRestaurants(mapper) {
   };
 }
 
+const favoritesDB = new NeDB('favorites')
+// combining update and create into one create endpoint
+const favoritesService = {
+  find: function (params, callback) {
+    return favoritesDB.find(params, callback);
+  },
+  get: function (id, params, callback) {
+    return favoritesDB.get(id, params, callback)
+  },
+  create: function(data, params, callback) {
+    if(data._id) {
+      const { _id, ..._data } = data;
+      favoritesDB.patch(_id, _data, params, callback);
+    } else {
+      favoritesDB.create(data, params, callback);
+    }
+	}
+}
+
 const api = feathers()
     .configure(feathers.rest())
     .configure(feathers.socketio())
@@ -65,7 +84,8 @@ const api = feathers()
     }))
     .use('/api/resources', feathers.static(apiResourcesPath))
     .use('/restaurants', new NeDB('restaurants'))
-    .use('/orders', new NeDB('orders'));
+    .use('/orders', new NeDB('orders'))
+    .use('/favorites', favoritesService);
 
   api.service('orders')
     .before(serviceHooks.addDelay(config.delay))
@@ -83,6 +103,19 @@ const api = feathers()
     .before({
       get: serviceHooks.alternateId('slug')
     }).after({
+      find: serviceHooks.wrapData
+    });
+
+  api.service('favorites')
+    .before(serviceHooks.addDelay(config.delay))
+    .before({
+      create: [
+        serviceHooks.checkRequiredFields(['userId', 'restaurantId', 'favorite', 'datetimeUpdated']), 
+        serviceHooks.checkUniqueConstraint(['userId', 'restaurantId'])  
+      ],
+      find: serviceHooks.checkQueryParam('userId'),
+    }).after({
+      create: serviceHooks.wrapData,
       find: serviceHooks.wrapData
     });
 

--- a/src/index.js
+++ b/src/index.js
@@ -50,7 +50,7 @@ const favoritesService = {
     } else {
       favoritesDB.create(data, params, callback);
     }
-	}
+  }
 }
 
 const api = feathers()


### PR DESCRIPTION
Created the favorites endpoints

GET /favorites  will return an error with the Message Error: Must query with field userId

GET /favorites?userId={userId} will return list of favorite belonging to the user

POST /favorites will branch to a create and update
  - Update will trigger if you pass the object with **_id**
  - Create will trigger if **_id** is missing. There is a pair unique constraint if 'userId', 'restaurantId' already exist
  - Both paths will require 'userId', 'restaurantId', 'favorite', and 'datetimeUpdated' properties 
 